### PR TITLE
pointing the link to icons demo

### DIFF
--- a/core-icon.html
+++ b/core-icon.html
@@ -29,7 +29,7 @@ Example using icon `cherry` from custom iconset `fruit`:
 See [core-iconset](#core-iconset) and [core-iconset-svg](#core-iconset-svg) for more information about
 how to use a custom iconset.
 
-See [core-icons](#core-icons) for the default set of icons. To use the default set of icons you'll need to include an import for `core-icons.html`.
+See [core-icons](http://www.polymer-project.org/components/core-icons/demo.html) for the default set of icons. To use the default set of icons you'll need to include an import for `core-icons.html`.
 
 @group Polymer Core Elements
 @element core-icon


### PR DESCRIPTION
Core-icons is a metapackage for few default iconsets rather than an element definition. Therefore, it does not have the docs like a normal element, so it is more illustrative to pint to the demo page here.
