### PR TITLE
Mention non-default built-in iconset import

### DIFF
--- a/core-icon.html
+++ b/core-icon.html
@@ -29,7 +29,7 @@ Example using icon `cherry` from custom iconset `fruit`:
 See [core-iconset](#core-iconset) and [core-iconset-svg](#core-iconset-svg) for more information about
 how to use a custom iconset.
 
-See [core-icons](http://www.polymer-project.org/components/core-icons/demo.html) for the default set of icons. To use the default set of icons you'll need to include an import for `core-icons.html`.
+See [core-icons](http://www.polymer-project.org/components/core-icons/demo.html) for the default set of icons. To use the default set of icons you'll need to include an import for `core-icons.html`. To use a different built-in set of icons, you'll need to include an import for `core-icons/iconsets/<iconset>.html`.
 
 @group Polymer Core Elements
 @element core-icon


### PR DESCRIPTION
If you want to use the non-default built-in iconset, you'll need to include an import for the relevant iconset. This was missing in the docs.
