### PR TITLE
Revert "Fix typo -- unnecessary HTML entities in the codeblocks."

### DIFF
--- a/core-icon.html
+++ b/core-icon.html
@@ -28,7 +28,7 @@ Example setting size to 32px x 32px:
 The core elements include several sets of icons. 
 To use the default set of icons, import  `core-icons.html` and use the `icon` attribute to specify an icon:
 
-    <!-- import default iconset and core-icon -->
+    &lt;!-- import default iconset and core-icon --&gt;
     <link rel="import" href="/components/core-icons/core-icons.html">
 
     <core-icon icon="menu"></core-icon>
@@ -36,7 +36,7 @@ To use the default set of icons, import  `core-icons.html` and use the `icon` at
 To use a different built-in set of icons, import  `core-icons/<iconset>-icons.html`, and
 specify the icon as `<iconset>:<icon>`. For example:
 
-    <!-- import communication iconset and core-icon -->
+    &lt;!-- import communication iconset and core-icon --&gt;
     <link rel="import" href="/components/core-icons/communication-icons.html">
 
     <core-icon icon="communication:email"></core-icon>


### PR DESCRIPTION
Reverts Polymer/core-icon#26.

This is required since this code block is in an html comment.
