### PR TITLE
Move custom `segment` style from core to demo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="core-icon.html">
 
   <style>
-    segment {
+    .box {
       display: block;
       position: relative;
       -webkit-box-sizing: border-box;
@@ -41,7 +41,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <template is="auto-binding">
   <div wrap horizontal layout>
     <template repeat="{{icon in $.meta.metaData.icons.iconNames}}">
-      <segment><core-icon icon="{{icon}}"></core-icon> {{icon}}</segment>
+      <div class="box">
+        <core-icon icon="{{icon}}"></core-icon> {{icon}}
+      </div>
     </template>
   </div>
   <core-iconset id="meta"></core-iconset>

--- a/demo.html
+++ b/demo.html
@@ -13,9 +13,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../webcomponentsjs/webcomponents.js"></script>
   <link rel="import" href="../core-icons/core-icons.html">
   <link rel="import" href="core-icon.html">
-  
+
   <style>
     segment {
+      display: block;
+      position: relative;
+      -webkit-box-sizing: border-box;
+      -ms-box-sizing: border-box;
+      box-sizing: border-box;
+      margin: 1em 0.5em;
+      padding: 1em;
+      background-color: white;
+      -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+      box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+      border-radius: 5px 5px 5px 5px;
       min-width: 200px;
     }
 


### PR DESCRIPTION
The `segment` styles are defined in layout.html in Polymer 0.5 and in
Polymer/layout for 0.8. Since the styles are only used here in the
core-icon demo, move them here to eliminate the overhead for other
clients of layout.html.
