### PR TITLE
Fix unhandled exception

### DIFF
--- a/core-icon.html
+++ b/core-icon.html
@@ -171,7 +171,12 @@ See [core-icons](http://www.polymer-project.org/components/core-icons/demo.html)
         }
 
         this.iconset = this.computeIconset(this.icon);
-        this.iconsetElement.applyIcon(this.root, this.iconName, this.theme);
+        if (this.iconsetElement)
+            this.iconsetElement.applyIcon(this.root, this.iconName, this.theme);
+        else {
+            if (this.icon)
+                console.warn("icon missing: ", this.icon);
+        }
       },
 
       srcChanged: function () {


### PR DESCRIPTION
The original code blows up if icon=="". This can happen in the wild, you want blank icon until you decide what it is.

The fix also prints out a "missing icon warning" if the icon is not "".
